### PR TITLE
Configure the XML parser to disable external entity resolution.

### DIFF
--- a/component/src/main/java/io/siddhi/extension/map/xml/sinkmapper/XMLSinkMapper.java
+++ b/component/src/main/java/io/siddhi/extension/map/xml/sinkmapper/XMLSinkMapper.java
@@ -156,6 +156,12 @@ public class XMLSinkMapper extends SinkMapper {
                 //We only need to check the parsability of xml we are generating. Hence setting validating to false.
                 factory.setNamespaceAware(true);
                 try {
+                    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                    factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                    factory.setXIncludeAware(false);
+                    factory.setExpandEntityReferences(false);
                     builder = factory.newDocumentBuilder();
                 } catch (ParserConfigurationException e) {
                     throw new SiddhiAppCreationException("Error occurred when initializing XML validator", e);


### PR DESCRIPTION
## Purpose
> $subject

## Approach
> https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes